### PR TITLE
Use Array#shelljoin instead of Array#join

### DIFF
--- a/lib/rsync/command.rb
+++ b/lib/rsync/command.rb
@@ -1,4 +1,5 @@
 require 'rsync/result'
+require 'shellwords'
 
 module Rsync
   # An rsync command to be run
@@ -8,7 +9,7 @@ module Rsync
     # @param args {Array}
     # @return {Result}
     def self.run(*args)
-      output = run_command("#{command} --itemize-changes #{args.join(" ")}")
+      output = run_command([command, "--itemize-changes", args].flatten.shelljoin)
       Result.new(output, $?.exitstatus)
     end
 


### PR DESCRIPTION
This pull request fixes the following issue:

The backup process is not executed correctly when filename contains shell special characters (e.g., `" "` and `"*"`).

These are example code:

```ruby
Rsync.run("/path/to/sr c", "/path/to/dest")
```

```ruby
Rsync.run("/path/to/sr*c", "/path/to/dest")`
```